### PR TITLE
removed redundant config color-identifiers-mode

### DIFF
--- a/emacs.org
+++ b/emacs.org
@@ -2145,17 +2145,6 @@
           (add-hook 'emacs-lisp-mode-hook 'paredit-mode))
     #+END_SRC
 
-*** Colored Variables
-
-    Color each variable, and downplay standard key words:
-
-    #+BEGIN_SRC elisp
-      (use-package color-identifiers-mode
-        :ensure t
-        :init
-        (add-hook 'emacs-lisp-mode-hook 'color-identifiers-mode))
-    #+END_SRC
-
 *** Nicer Paren Matching
 
     The reverse mode of the default parenthesis matching doesn’t match


### PR DESCRIPTION
The color-identifiers-mode configuration is already present in starting of Emacs lisp section. 
https://github.com/howardabrams/dot-files/blob/master/emacs.org#emacs-lisp