### PR TITLE
minor typo in docstring

### DIFF
--- a/emacs-eshell.org
+++ b/emacs-eshell.org
@@ -2,7 +2,7 @@
 #+AUTHOR: Howard Abrams
 #+EMAIL:  howard.abrams@gmail.com
 #+DATE:   [2014-02-27 Thu]
-#+TAGS:   emacs
+#+TAGS:   emacs
 
 My frustration with shells makes me enjoy Emacs Shell, but there are
 some significant differences to address. To this end, I [[http://www.howardism.org/Technical/Emacs/eshell-fun.html][documented
@@ -591,7 +591,7 @@ I find it a shame that I can not successfully use =use-package= with the
    Finally
    #+BEGIN_SRC elisp
      (defun eshell-here-on-line (p)
-       "Search the current line for an IP address or hostname, and call the `eshell-there' function.
+       "Search the current line for an IP address or hostname, and call the `eshell-here' function.
 
      Call with PREFIX to connect with the `root' useraccount, via
      `sudo'."


### PR DESCRIPTION
I found this repository following a link from youtube (https://www.youtube.com/watch?v=pSjrwSI4OHk) while looking for Tramp documentation (thank you for your video btw!)

I found this little thing that confused me at the beginning, then I thought it was just a typo.
I hope this PR could be useful. Thanks again for your video