### PR TITLE
Uses equal to compare mode names

### DIFF
--- a/emacs-org.org
+++ b/emacs-org.org
@@ -221,7 +221,7 @@ Emacs love affair.
       (let* ((clip (if (eq system-type 'darwin)
                        "pbpaste -Prefer rts"
                      "xclip -out -selection 'clipboard' -t text/html"))
-             (format (if (eq mode-name "Org") "org" "markdown"))
+             (format (if (equal mode-name "Org") "org" "markdown"))
              (pandoc (concat "pandoc -f rts -t " format))
              (cmd    (concat clip " | " pandoc))
              (text   (shell-command-to-string cmd)))


### PR DESCRIPTION
`(eq x y)` seems to be true if and only if `x` and `y` are the same identical object. I don't yet understand how emacs lisp compare strings, but this gives me `nil`. Changing it to `equal` works.

Thanks for that function! 🙌🙌🙌 It really makes my life easier. 

I've changed this `xclip` to `wl-paste` to be able to use it on wayland.
```diff
-                 "xclip -out -selection 'clipboard' -t text/html"))
+                 "wl-paste -t text/html"))
```